### PR TITLE
docs: add usage section and fix demo.py for beam-draft-rl

### DIFF
--- a/beam-draft-rl/README.md
+++ b/beam-draft-rl/README.md
@@ -40,5 +40,27 @@ Combines the precision of verifiable physics rewards (BeamPERL) with the efficie
 12. **Documentation & Demo** [DONE]
     - Final README and "Drafting vs Traditional CoT" token savings demo.
 
+## 🛠 Usage
+
+To use Beam-Draft RL (BDRL):
+
+### 1. Run the Demo
+Compare "Drafting" vs "Traditional CoT" token savings and performance.
+```bash
+python3 src/demo.py
+```
+
+### 2. Run the Benchmark
+Evaluate accuracy and efficiency metrics programmatically.
+```bash
+python3 -m src.benchmark
+```
+
+### 3. Solve a Problem (CLI)
+Use the CLI to solve a mechanics problem using a trained draft-thinking model.
+```bash
+python3 -m src.cli solve "cantilever beam 5m with 10kN at free end"
+```
+
 ---
 Part of the **ClawWork** series. 🦞

--- a/beam-draft-rl/src/demo.py
+++ b/beam-draft-rl/src/demo.py
@@ -1,4 +1,9 @@
 import sys
+import os
+
+# Ensure src is in the python path
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+
 from engine import PhysicsEngine
 from model_wrapper import DraftWrapper
 import time

--- a/beam-draft-rl/src/engine.py
+++ b/beam-draft-rl/src/engine.py
@@ -53,3 +53,13 @@ class PhysicsEngine:
             'R0': (-R_L).to(self.ureg.newton), # Reaction at 0
             'RL': (-R_R).to(self.ureg.newton)  # Reaction at L
         }
+
+    def calculate_max_moment(self, load, length):
+        """
+        Calculates max moment for a simply supported beam with a central point load.
+        """
+        P = self.ureg(str(load) + "N")
+        L = self.ureg(str(length) + "m")
+        # For a simply supported beam with a central load: Max Moment = PL/4
+        M = (P * L) / 4
+        return float(M.to(self.ureg.newton * self.ureg.meter).magnitude)


### PR DESCRIPTION
This PR addresses #68 by:

1. Adding a `Usage` section to `beam-draft-rl/README.md` with examples for `demo.py`, `benchmark.py`, and the CLI.
2. Fixing `demo.py` to be runnable from the root and correctly importing local modules.
3. Implementing `calculate_max_moment` in `engine.py` to support the demo script.

Fixes #68