### PR TITLE
fix: raise clear error when --data is a directory

### DIFF
--- a/kepler-skills-distiller/src/distillation.py
+++ b/kepler-skills-distiller/src/distillation.py
@@ -154,6 +154,13 @@ class MasteryDataset(Dataset):
             logger.warning(f"Data file not found: {self.data_path}")
             return
         
+        # Check if data_path is a directory (Issue #71)
+        if self.data_path.is_dir():
+            raise ValueError(
+                f"Expected a file path, got a directory: {self.data_path}. "
+                f"Please provide a path to a JSONL file (e.g., data/training.jsonl)"
+            )
+        
         with open(self.data_path, "r") as f:
             for line in f:
                 if line.strip():


### PR DESCRIPTION
## Summary

Fixes #71

## Problem

When users pass a directory path to `--data`, the code would crash with `IsADirectoryError` when trying to open it as a file.

## Solution

Added validation in `MasteryDataset._load_data()` to check if the path is a directory and raise a clear error message:

```python
if self.data_path.is_dir():
    raise ValueError(
        f"Expected a file path, got a directory: {self.data_path}. "
        f"Please provide a path to a JSONL file (e.g., data/training.jsonl)"
    )
```

## Changes

- Added directory check in `kepler-skills-distiller/src/distillation.py`
- Provides actionable error message with example

## Testing

```bash
# Before: crashes with IsADirectoryError
python -m src.cli distill --data ./data

# After: clear error message
python -m src.cli distill --data ./data
# ValueError: Expected a file path, got a directory: ./data
```