### PR TITLE
Step 11: CLI & Visualization

### DIFF
--- a/parallel-agentic-plan-over-graph/src/cli.py
+++ b/parallel-agentic-plan-over-graph/src/cli.py
@@ -1,0 +1,241 @@
+"""Main CLI entry point for PAPoG.
+
+Usage::
+
+    python -m src.cli run --goal "Build a chatbot" --workers 4
+    python -m src.cli visualize --goal "Build a chatbot" --output graph.dot
+    python -m src.cli scenario --name deep_research
+    python -m src.cli list-scenarios
+
+Can also be invoked as ``papog`` if installed as a console_scripts entry.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+from src.benchmark import BenchmarkRunner, format_result
+from src.visualizer import export_dot, export_png, export_svg
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def _handle_run(args: argparse.Namespace) -> int:
+    """Run a goal through the full PAPoG pipeline."""
+    runner = BenchmarkRunner(
+        max_workers=args.workers,
+        max_retries=args.max_retries,
+    )
+    result = runner.run_scenario(goal=args.goal, scenario_name="cli-run")
+
+    print(format_result(result))
+
+    # Optionally save graph visualization
+    if args.output_dir:
+        outdir = Path(args.output_dir)
+        outdir.mkdir(parents=True, exist_ok=True)
+        dot_path = str(outdir / "graph.dot")
+        from src.architect import Architect
+
+        architect = Architect()
+        graph = architect.decompose(args.goal)
+        export_dot(graph, dot_path)
+        print(f"\nGraph exported to: {dot_path}")
+
+    return 0 if result.nodes_failed == 0 else 1
+
+
+def _handle_visualize(args: argparse.Namespace) -> int:
+    """Decompose a goal and visualize the resulting task graph."""
+    from src.architect import Architect
+
+    architect = Architect()
+    graph = architect.decompose(args.goal)
+
+    output = args.output or "graph"
+    fmt = args.format
+
+    if fmt == "dot":
+        if not output.endswith(".dot"):
+            output += ".dot"
+        export_dot(graph, output)
+        print(f"DOT graph written to: {output}")
+    elif fmt == "png":
+        if not output.endswith(".png"):
+            output += ".png"
+        try:
+            result_path = export_png(graph, output)
+            print(f"PNG graph written to: {result_path}")
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            # Fall back to DOT
+            fallback = output.replace(".png", ".dot")
+            export_dot(graph, fallback)
+            print(f"Fell back to DOT export: {fallback}")
+            return 1
+    elif fmt == "svg":
+        if not output.endswith(".svg"):
+            output += ".svg"
+        try:
+            result_path = export_svg(graph, output)
+            print(f"SVG graph written to: {result_path}")
+        except RuntimeError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            fallback = output.replace(".svg", ".dot")
+            export_dot(graph, fallback)
+            print(f"Fell back to DOT export: {fallback}")
+            return 1
+
+    return 0
+
+
+def _handle_scenario(args: argparse.Namespace) -> int:
+    """Run a predefined benchmark scenario."""
+    runner = BenchmarkRunner(
+        max_workers=args.workers,
+    )
+    try:
+        result = runner.run_named_scenario(args.name)
+    except (ModuleNotFoundError, ImportError) as exc:
+        print(f"Error loading scenario '{args.name}': {exc}", file=sys.stderr)
+        return 1
+
+    print(format_result(result))
+    return 0 if result.nodes_failed == 0 else 1
+
+
+def _handle_list_scenarios(args: argparse.Namespace) -> int:
+    """List available benchmark scenarios."""
+    try:
+        scenarios = BenchmarkRunner.list_scenarios()
+    except Exception as exc:
+        print(f"Error discovering scenarios: {exc}", file=sys.stderr)
+        return 1
+
+    if not scenarios:
+        print("No scenarios found.")
+        return 0
+
+    print("Available scenarios:")
+    for name in scenarios:
+        print(f"  • {name}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construct the top-level argument parser with subcommands."""
+    parser = argparse.ArgumentParser(
+        prog="papog",
+        description="PAPoG — Parallel Agentic Plan-over-Graph CLI",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # --- run ---------------------------------------------------------------
+    run_parser = subparsers.add_parser(
+        "run",
+        help="Run a goal through the full PAPoG pipeline",
+    )
+    run_parser.add_argument(
+        "--goal", required=True, type=str, help="Goal to execute"
+    )
+    run_parser.add_argument(
+        "--workers", type=int, default=4, help="Worker thread count (default: 4)"
+    )
+    run_parser.add_argument(
+        "--max-retries",
+        type=int,
+        default=2,
+        help="Max re-plan retries per node (default: 2)",
+    )
+    run_parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=None,
+        help="Directory to save graph visualization",
+    )
+
+    # --- visualize ---------------------------------------------------------
+    viz_parser = subparsers.add_parser(
+        "visualize",
+        help="Decompose a goal and visualize the task graph",
+    )
+    viz_parser.add_argument(
+        "--goal", required=True, type=str, help="Goal to decompose"
+    )
+    viz_parser.add_argument(
+        "--output",
+        type=str,
+        default=None,
+        help="Output file path (default: graph.<format>)",
+    )
+    viz_parser.add_argument(
+        "--format",
+        type=str,
+        choices=["dot", "png", "svg"],
+        default="dot",
+        help="Output format (default: dot)",
+    )
+
+    # --- scenario ----------------------------------------------------------
+    scen_parser = subparsers.add_parser(
+        "scenario",
+        help="Run a predefined benchmark scenario",
+    )
+    scen_parser.add_argument(
+        "--name", required=True, type=str, help="Scenario name"
+    )
+    scen_parser.add_argument(
+        "--workers", type=int, default=4, help="Worker thread count (default: 4)"
+    )
+
+    # --- list-scenarios ----------------------------------------------------
+    subparsers.add_parser(
+        "list-scenarios",
+        help="List available benchmark scenarios",
+    )
+
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Parse arguments and dispatch to the appropriate handler."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command is None:
+        parser.print_help()
+        return 0
+
+    handlers = {
+        "run": _handle_run,
+        "visualize": _handle_visualize,
+        "scenario": _handle_scenario,
+        "list-scenarios": _handle_list_scenarios,
+    }
+
+    handler = handlers.get(args.command)
+    if handler is None:
+        parser.print_help()
+        return 1
+
+    return handler(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/parallel-agentic-plan-over-graph/src/visualizer.py
+++ b/parallel-agentic-plan-over-graph/src/visualizer.py
@@ -1,0 +1,270 @@
+"""Graph visualization module for PAPoG.
+
+Exports TaskGraph state to DOT, PNG, and SVG formats with status-based
+node coloring.  Also renders execution timelines from BenchmarkResult.
+
+DOT text export always works.  PNG/SVG require the ``graphviz`` Python
+package *and* the system ``dot`` binary — their absence is handled
+gracefully with clear error messages.
+"""
+
+from __future__ import annotations
+
+import shutil
+import textwrap
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from src.models import TaskGraph, TaskStatus
+
+if TYPE_CHECKING:
+    from src.benchmark import BenchmarkResult
+
+# ---------------------------------------------------------------------------
+# Status → colour mapping
+# ---------------------------------------------------------------------------
+
+STATUS_COLORS: dict[TaskStatus, str] = {
+    TaskStatus.PENDING: "gray",
+    TaskStatus.RUNNING: "dodgerblue",
+    TaskStatus.COMPLETED: "green3",
+    TaskStatus.FAILED: "red",
+    TaskStatus.SKIPPED: "orange",
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _truncate(text: str, maxlen: int = 40) -> str:
+    """Truncate *text* to *maxlen* characters, adding '…' if needed."""
+    if len(text) <= maxlen:
+        return text
+    return text[: maxlen - 1] + "…"
+
+
+def _dot_escape(text: str) -> str:
+    """Escape characters that are special in DOT labels."""
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _get_graphviz():
+    """Import and return the ``graphviz`` Python package, or ``None``."""
+    try:
+        import graphviz  # type: ignore[import-untyped]
+
+        return graphviz
+    except ImportError:
+        return None
+
+
+def _has_dot_binary() -> bool:
+    """Return True if the ``dot`` binary is on PATH."""
+    return shutil.which("dot") is not None
+
+
+# ---------------------------------------------------------------------------
+# DOT source generation (always works — no external deps)
+# ---------------------------------------------------------------------------
+
+
+def _build_dot_source(graph: TaskGraph) -> str:
+    """Return a DOT-language string representing *graph*."""
+    lines: list[str] = []
+    lines.append("digraph PAPoG {")
+    lines.append('    rankdir=LR;')
+    lines.append('    node [shape=box, style=filled, fontname="Helvetica"];')
+    lines.append("")
+
+    for node_id, node in graph.nodes.items():
+        color = STATUS_COLORS.get(node.status, "white")
+        label = _dot_escape(f"{node_id}\\n{_truncate(node.description)}")
+        lines.append(
+            f'    "{_dot_escape(node_id)}" '
+            f'[label="{label}", fillcolor="{color}"];'
+        )
+
+    lines.append("")
+
+    for node_id, node in graph.nodes.items():
+        for dep in node.dependencies:
+            lines.append(
+                f'    "{_dot_escape(dep)}" -> "{_dot_escape(node_id)}";'
+            )
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Public API — export functions
+# ---------------------------------------------------------------------------
+
+
+def export_dot(graph: TaskGraph, filepath: str) -> str:
+    """Write the graph as a DOT file and return the DOT source string.
+
+    This function has **no external dependencies** — it always works.
+    """
+    source = _build_dot_source(graph)
+    Path(filepath).write_text(source, encoding="utf-8")
+    return source
+
+
+def export_png(graph: TaskGraph, filepath: str) -> str:
+    """Render the graph as a PNG image.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``graphviz`` Python package or the ``dot`` binary is
+        missing.
+
+    Returns the output filepath.
+    """
+    gv = _get_graphviz()
+    if gv is None:
+        raise RuntimeError(
+            "The 'graphviz' Python package is required for PNG export. "
+            "Install it with: pip install graphviz"
+        )
+    if not _has_dot_binary():
+        raise RuntimeError(
+            "The 'dot' binary (Graphviz system package) is required for "
+            "PNG rendering. Install it with: apt install graphviz"
+        )
+
+    source = _build_dot_source(graph)
+    # graphviz.Source.render writes <filepath>.png
+    src = gv.Source(source)
+    # Strip .png suffix if present — graphviz appends the format extension
+    outpath = filepath
+    if outpath.endswith(".png"):
+        outpath = outpath[:-4]
+    src.render(outpath, format="png", cleanup=True)
+    return f"{outpath}.png"
+
+
+def export_svg(graph: TaskGraph, filepath: str) -> str:
+    """Render the graph as an SVG image.
+
+    Raises
+    ------
+    RuntimeError
+        If the ``graphviz`` Python package or the ``dot`` binary is
+        missing.
+
+    Returns the output filepath.
+    """
+    gv = _get_graphviz()
+    if gv is None:
+        raise RuntimeError(
+            "The 'graphviz' Python package is required for SVG export. "
+            "Install it with: pip install graphviz"
+        )
+    if not _has_dot_binary():
+        raise RuntimeError(
+            "The 'dot' binary (Graphviz system package) is required for "
+            "SVG rendering. Install it with: apt install graphviz"
+        )
+
+    source = _build_dot_source(graph)
+    src = gv.Source(source)
+    outpath = filepath
+    if outpath.endswith(".svg"):
+        outpath = outpath[:-4]
+    src.render(outpath, format="svg", cleanup=True)
+    return f"{outpath}.svg"
+
+
+# ---------------------------------------------------------------------------
+# Execution timeline
+# ---------------------------------------------------------------------------
+
+
+def render_execution_timeline(result: "BenchmarkResult", filepath: str) -> str:
+    """Generate a DOT-based timeline visualization of execution events.
+
+    Each node is shown as a horizontal bar spanning its RUNNING→COMPLETED
+    duration.  Uses the ``execution_timeline`` entries.
+
+    Returns the DOT source (always works).  If *filepath* ends with
+    ``.png`` or ``.svg`` and graphviz is available, the rendered image is
+    also produced.
+    """
+    from src.benchmark import BenchmarkResult  # noqa: F811 — deferred import
+
+    lines: list[str] = []
+    lines.append("digraph Timeline {")
+    lines.append('    rankdir=LR;')
+    lines.append('    node [shape=record, style=filled, fontname="Helvetica"];')
+    lines.append("")
+
+    # Collect start/end per node
+    node_times: dict[str, dict[str, float]] = {}
+    for entry in result.execution_timeline:
+        nid = entry.node_id
+        if nid not in node_times:
+            node_times[nid] = {}
+        if entry.to_status == "running":
+            node_times[nid]["start"] = entry.timestamp
+        elif entry.to_status in ("completed", "failed"):
+            node_times[nid]["end"] = entry.timestamp
+            node_times[nid]["final_status"] = entry.to_status
+
+    if not node_times:
+        # Empty timeline — produce minimal valid DOT
+        lines.append('    empty [label="No events", fillcolor="gray"];')
+        lines.append("}")
+        source = "\n".join(lines)
+        Path(filepath).write_text(source, encoding="utf-8")
+        return source
+
+    # Normalise timestamps to start at 0
+    min_t = min(
+        t.get("start", float("inf"))
+        for t in node_times.values()
+    )
+
+    for nid, times in sorted(node_times.items()):
+        start = times.get("start", min_t) - min_t
+        end = times.get("end", start) - min_t
+        duration = end - start
+        status = times.get("final_status", "running")
+        color = {
+            "completed": "green3",
+            "failed": "red",
+            "running": "dodgerblue",
+        }.get(status, "gray")
+        label = _dot_escape(
+            f"{nid} | {start:.3f}s → {end:.3f}s ({duration:.3f}s)"
+        )
+        lines.append(
+            f'    "{_dot_escape(nid)}" '
+            f'[label="{label}", fillcolor="{color}"];'
+        )
+
+    lines.append("}")
+    source = "\n".join(lines)
+
+    # Write DOT source
+    dot_path = filepath
+    if dot_path.endswith((".png", ".svg")):
+        dot_path = filepath.rsplit(".", 1)[0] + ".dot"
+    Path(dot_path).write_text(source, encoding="utf-8")
+
+    # Attempt rendered output if requested
+    gv = _get_graphviz()
+    if gv and _has_dot_binary():
+        fmt = None
+        if filepath.endswith(".png"):
+            fmt = "png"
+        elif filepath.endswith(".svg"):
+            fmt = "svg"
+        if fmt:
+            base = filepath.rsplit(".", 1)[0]
+            src = gv.Source(source)
+            src.render(base, format=fmt, cleanup=True)
+
+    return source

--- a/parallel-agentic-plan-over-graph/tests/test_cli.py
+++ b/parallel-agentic-plan-over-graph/tests/test_cli.py
@@ -1,0 +1,203 @@
+"""Tests for src.cli — argument parsing and subcommand dispatch."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from src.cli import build_parser, main
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_dir():
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestBuildParser:
+    """Verify argument parsing for all subcommands."""
+
+    def test_run_minimal(self):
+        parser = build_parser()
+        args = parser.parse_args(["run", "--goal", "Build a chatbot"])
+        assert args.command == "run"
+        assert args.goal == "Build a chatbot"
+        assert args.workers == 4
+        assert args.max_retries == 2
+        assert args.output_dir is None
+
+    def test_run_all_options(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "run", "--goal", "Build X",
+            "--workers", "8", "--max-retries", "5",
+            "--output-dir", "/tmp/out",
+        ])
+        assert args.workers == 8
+        assert args.max_retries == 5
+        assert args.output_dir == "/tmp/out"
+
+    def test_visualize_minimal(self):
+        parser = build_parser()
+        args = parser.parse_args(["visualize", "--goal", "Analyse data"])
+        assert args.command == "visualize"
+        assert args.goal == "Analyse data"
+        assert args.format == "dot"
+        assert args.output is None
+
+    def test_visualize_all_options(self):
+        parser = build_parser()
+        args = parser.parse_args([
+            "visualize", "--goal", "Plan",
+            "--output", "my_graph.png",
+            "--format", "png",
+        ])
+        assert args.output == "my_graph.png"
+        assert args.format == "png"
+
+    def test_visualize_format_choices(self):
+        parser = build_parser()
+        for fmt in ("dot", "png", "svg"):
+            args = parser.parse_args(["visualize", "--goal", "X", "--format", fmt])
+            assert args.format == fmt
+
+    def test_visualize_invalid_format(self):
+        parser = build_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["visualize", "--goal", "X", "--format", "pdf"])
+
+    def test_scenario_minimal(self):
+        parser = build_parser()
+        args = parser.parse_args(["scenario", "--name", "deep_research"])
+        assert args.command == "scenario"
+        assert args.name == "deep_research"
+        assert args.workers == 4
+
+    def test_scenario_with_workers(self):
+        parser = build_parser()
+        args = parser.parse_args(["scenario", "--name", "test", "--workers", "2"])
+        assert args.workers == 2
+
+    def test_list_scenarios(self):
+        parser = build_parser()
+        args = parser.parse_args(["list-scenarios"])
+        assert args.command == "list-scenarios"
+
+    def test_no_command(self):
+        parser = build_parser()
+        args = parser.parse_args([])
+        assert args.command is None
+
+
+# ---------------------------------------------------------------------------
+# Subcommand execution
+# ---------------------------------------------------------------------------
+
+
+class TestMainRun:
+    """Test the 'run' subcommand executes without crashing."""
+
+    def test_run_basic_goal(self, capsys):
+        exit_code = main(["run", "--goal", "Build a simple chatbot"])
+        captured = capsys.readouterr()
+        assert "PAPoG Benchmark Results" in captured.out
+        assert exit_code == 0
+
+    def test_run_with_output_dir(self, tmp_dir, capsys):
+        exit_code = main([
+            "run", "--goal", "Build a chatbot",
+            "--output-dir", tmp_dir,
+        ])
+        captured = capsys.readouterr()
+        assert "PAPoG Benchmark Results" in captured.out
+        assert Path(os.path.join(tmp_dir, "graph.dot")).exists()
+        assert exit_code == 0
+
+
+class TestMainVisualize:
+    """Test the 'visualize' subcommand."""
+
+    def test_visualize_dot(self, tmp_dir, capsys):
+        outpath = os.path.join(tmp_dir, "viz.dot")
+        exit_code = main(["visualize", "--goal", "Plan a project", "--output", outpath])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert Path(outpath).exists()
+        content = Path(outpath).read_text()
+        assert "digraph" in content
+
+    def test_visualize_dot_default_name(self, capsys, monkeypatch, tmp_dir):
+        monkeypatch.chdir(tmp_dir)
+        exit_code = main(["visualize", "--goal", "Anything"])
+        assert exit_code == 0
+        assert Path(os.path.join(tmp_dir, "graph.dot")).exists()
+
+    def test_visualize_png_fallback_no_dot(self, tmp_dir, capsys):
+        """When dot binary is missing, PNG falls back to DOT."""
+        _has_dot = shutil.which("dot") is not None
+        if _has_dot:
+            pytest.skip("dot binary is installed — can't test fallback")
+        outpath = os.path.join(tmp_dir, "viz.png")
+        exit_code = main([
+            "visualize", "--goal", "Test",
+            "--output", outpath,
+            "--format", "png",
+        ])
+        # Should exit 1 with fallback
+        assert exit_code == 1
+        # DOT fallback should exist
+        fallback = os.path.join(tmp_dir, "viz.dot")
+        assert Path(fallback).exists()
+
+
+class TestMainScenario:
+    """Test the 'scenario' subcommand."""
+
+    def test_run_deep_research(self, capsys):
+        exit_code = main(["scenario", "--name", "deep_research"])
+        captured = capsys.readouterr()
+        assert "PAPoG Benchmark Results" in captured.out
+        assert isinstance(exit_code, int)
+
+    def test_run_invalid_scenario(self, capsys):
+        exit_code = main(["scenario", "--name", "nonexistent_xyz"])
+        assert exit_code == 1
+
+
+class TestMainListScenarios:
+    """Test the 'list-scenarios' subcommand."""
+
+    def test_lists_scenarios(self, capsys):
+        exit_code = main(["list-scenarios"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "Available scenarios:" in captured.out
+        # Should have at least deep_research
+        assert "deep_research" in captured.out
+
+
+class TestMainNoCommand:
+    """Test that no command prints help and exits 0."""
+
+    def test_no_args(self, capsys):
+        exit_code = main([])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        # Should show usage info
+        assert "papog" in captured.out.lower() or "usage" in captured.out.lower()

--- a/parallel-agentic-plan-over-graph/tests/test_visualizer.py
+++ b/parallel-agentic-plan-over-graph/tests/test_visualizer.py
@@ -1,0 +1,311 @@
+"""Tests for src.visualizer — graph export and timeline rendering."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.benchmark import BenchmarkResult, TimelineEntry
+from src.models import TaskGraph, TaskNode, TaskStatus
+from src.visualizer import (
+    STATUS_COLORS,
+    _build_dot_source,
+    _truncate,
+    export_dot,
+    export_png,
+    export_svg,
+    render_execution_timeline,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tmp_dir():
+    """Yield a temporary directory, cleaned up afterwards."""
+    d = tempfile.mkdtemp()
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture
+def simple_graph() -> TaskGraph:
+    """A basic 3-node graph: A → B → C."""
+    graph = TaskGraph()
+    graph.add_node(TaskNode(id="A", description="First task", dependencies=[]))
+    graph.add_node(TaskNode(id="B", description="Second task", dependencies=["A"]))
+    graph.add_node(TaskNode(id="C", description="Third task", dependencies=["B"]))
+    return graph
+
+
+@pytest.fixture
+def diamond_graph() -> TaskGraph:
+    """Diamond: A → B, A → C, B → D, C → D."""
+    graph = TaskGraph()
+    graph.add_node(TaskNode(id="A", description="Root", dependencies=[]))
+    graph.add_node(TaskNode(id="B", description="Left branch", dependencies=["A"]))
+    graph.add_node(TaskNode(id="C", description="Right branch", dependencies=["A"]))
+    graph.add_node(TaskNode(id="D", description="Join", dependencies=["B", "C"]))
+    return graph
+
+
+@pytest.fixture
+def mixed_status_graph() -> TaskGraph:
+    """Graph with nodes in different statuses."""
+    graph = TaskGraph()
+    n1 = TaskNode(id="done", description="Completed task", dependencies=[])
+    n1.status = TaskStatus.COMPLETED
+    n2 = TaskNode(id="running", description="Running task", dependencies=[])
+    n2.status = TaskStatus.RUNNING
+    n3 = TaskNode(id="fail", description="Failed task", dependencies=[])
+    n3.status = TaskStatus.FAILED
+    n4 = TaskNode(id="skip", description="Skipped task", dependencies=[])
+    n4.status = TaskStatus.SKIPPED
+    n5 = TaskNode(id="wait", description="Pending task", dependencies=[])
+    n5.status = TaskStatus.PENDING
+    for n in [n1, n2, n3, n4, n5]:
+        graph.add_node(n)
+    return graph
+
+
+@pytest.fixture
+def empty_graph() -> TaskGraph:
+    """An empty graph with no nodes."""
+    return TaskGraph()
+
+
+@pytest.fixture
+def single_node_graph() -> TaskGraph:
+    """Graph with a single node."""
+    graph = TaskGraph()
+    graph.add_node(TaskNode(id="solo", description="Lone task", dependencies=[]))
+    return graph
+
+
+@pytest.fixture
+def large_graph() -> TaskGraph:
+    """Graph with 50 chained nodes."""
+    graph = TaskGraph()
+    for i in range(50):
+        deps = [f"node_{i - 1}"] if i > 0 else []
+        graph.add_node(
+            TaskNode(id=f"node_{i}", description=f"Task number {i}", dependencies=deps)
+        )
+    return graph
+
+
+# ---------------------------------------------------------------------------
+# Truncation helper
+# ---------------------------------------------------------------------------
+
+
+class TestTruncate:
+    def test_short_string_unchanged(self):
+        assert _truncate("hello", 40) == "hello"
+
+    def test_long_string_truncated(self):
+        result = _truncate("a" * 60, 40)
+        assert len(result) == 40
+        assert result.endswith("…")
+
+    def test_exact_length(self):
+        assert _truncate("a" * 40, 40) == "a" * 40
+
+
+# ---------------------------------------------------------------------------
+# DOT source generation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDotSource:
+    def test_valid_dot_structure(self, simple_graph):
+        dot = _build_dot_source(simple_graph)
+        assert dot.startswith("digraph PAPoG {")
+        assert dot.endswith("}")
+
+    def test_contains_all_nodes(self, simple_graph):
+        dot = _build_dot_source(simple_graph)
+        for nid in ("A", "B", "C"):
+            assert f'"{nid}"' in dot
+
+    def test_contains_edges(self, simple_graph):
+        dot = _build_dot_source(simple_graph)
+        assert '"A" -> "B"' in dot
+        assert '"B" -> "C"' in dot
+
+    def test_diamond_edges(self, diamond_graph):
+        dot = _build_dot_source(diamond_graph)
+        assert '"A" -> "B"' in dot
+        assert '"A" -> "C"' in dot
+        assert '"B" -> "D"' in dot
+        assert '"C" -> "D"' in dot
+
+    def test_empty_graph(self, empty_graph):
+        dot = _build_dot_source(empty_graph)
+        assert "digraph PAPoG {" in dot
+        # No node definitions
+        assert "fillcolor" not in dot
+
+    def test_single_node(self, single_node_graph):
+        dot = _build_dot_source(single_node_graph)
+        assert '"solo"' in dot
+        # No edges
+        assert "->" not in dot
+
+
+# ---------------------------------------------------------------------------
+# Status-based coloring
+# ---------------------------------------------------------------------------
+
+
+class TestStatusColoring:
+    def test_all_statuses_have_colors(self):
+        for status in TaskStatus:
+            assert status in STATUS_COLORS
+
+    def test_color_in_dot_output(self, mixed_status_graph):
+        dot = _build_dot_source(mixed_status_graph)
+        assert 'fillcolor="green3"' in dot  # COMPLETED
+        assert 'fillcolor="dodgerblue"' in dot  # RUNNING
+        assert 'fillcolor="red"' in dot  # FAILED
+        assert 'fillcolor="orange"' in dot  # SKIPPED
+        assert 'fillcolor="gray"' in dot  # PENDING
+
+
+# ---------------------------------------------------------------------------
+# export_dot
+# ---------------------------------------------------------------------------
+
+
+class TestExportDot:
+    def test_writes_file(self, simple_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "test.dot")
+        source = export_dot(simple_graph, outpath)
+        assert Path(outpath).exists()
+        content = Path(outpath).read_text()
+        assert content == source
+        assert "digraph" in content
+
+    def test_empty_graph_export(self, empty_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "empty.dot")
+        source = export_dot(empty_graph, outpath)
+        assert "digraph" in source
+
+    def test_large_graph_export(self, large_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "large.dot")
+        source = export_dot(large_graph, outpath)
+        assert source.count("->") == 49  # 50 nodes, 49 edges in chain
+
+
+# ---------------------------------------------------------------------------
+# export_png / export_svg (require dot binary)
+# ---------------------------------------------------------------------------
+
+_has_dot = shutil.which("dot") is not None
+
+
+@pytest.mark.skipif(not _has_dot, reason="graphviz dot binary not installed")
+class TestExportPng:
+    def test_creates_png(self, simple_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "test.png")
+        result_path = export_png(simple_graph, outpath)
+        assert Path(result_path).exists()
+        assert result_path.endswith(".png")
+
+
+@pytest.mark.skipif(not _has_dot, reason="graphviz dot binary not installed")
+class TestExportSvg:
+    def test_creates_svg(self, simple_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "test.svg")
+        result_path = export_svg(simple_graph, outpath)
+        assert Path(result_path).exists()
+        assert result_path.endswith(".svg")
+
+
+class TestExportPngNoDot:
+    """When dot binary is unavailable, export_png should raise RuntimeError."""
+
+    @pytest.mark.skipif(_has_dot, reason="dot binary IS installed")
+    def test_raises_without_dot(self, simple_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "fail.png")
+        with pytest.raises(RuntimeError, match="dot"):
+            export_png(simple_graph, outpath)
+
+    @pytest.mark.skipif(_has_dot, reason="dot binary IS installed")
+    def test_svg_raises_without_dot(self, simple_graph, tmp_dir):
+        outpath = os.path.join(tmp_dir, "fail.svg")
+        with pytest.raises(RuntimeError, match="dot"):
+            export_svg(simple_graph, outpath)
+
+
+# ---------------------------------------------------------------------------
+# Execution timeline
+# ---------------------------------------------------------------------------
+
+
+class TestRenderExecutionTimeline:
+    def test_basic_timeline(self, tmp_dir):
+        result = BenchmarkResult(
+            scenario_name="test",
+            goal="test goal",
+            execution_timeline=[
+                TimelineEntry(
+                    timestamp=0.0, node_id="A", from_status="pending", to_status="running"
+                ),
+                TimelineEntry(
+                    timestamp=0.5, node_id="A", from_status="running", to_status="completed"
+                ),
+                TimelineEntry(
+                    timestamp=0.1, node_id="B", from_status="pending", to_status="running"
+                ),
+                TimelineEntry(
+                    timestamp=0.8, node_id="B", from_status="running", to_status="failed"
+                ),
+            ],
+        )
+        outpath = os.path.join(tmp_dir, "timeline.dot")
+        source = render_execution_timeline(result, outpath)
+        assert "digraph Timeline" in source
+        assert '"A"' in source
+        assert '"B"' in source
+        assert 'fillcolor="green3"' in source  # A completed
+        assert 'fillcolor="red"' in source  # B failed
+        assert Path(outpath).exists()
+
+    def test_empty_timeline(self, tmp_dir):
+        result = BenchmarkResult(
+            scenario_name="empty",
+            goal="nothing",
+            execution_timeline=[],
+        )
+        outpath = os.path.join(tmp_dir, "empty_timeline.dot")
+        source = render_execution_timeline(result, outpath)
+        assert "digraph Timeline" in source
+        assert "No events" in source
+
+    def test_timeline_writes_dot_for_png_path(self, tmp_dir):
+        """Even when requesting .png, the DOT source should be written."""
+        result = BenchmarkResult(
+            scenario_name="test",
+            goal="test",
+            execution_timeline=[
+                TimelineEntry(
+                    timestamp=1.0, node_id="X", from_status="pending", to_status="running"
+                ),
+                TimelineEntry(
+                    timestamp=2.0, node_id="X", from_status="running", to_status="completed"
+                ),
+            ],
+        )
+        outpath = os.path.join(tmp_dir, "timeline.png")
+        source = render_execution_timeline(result, outpath)
+        # DOT file should have been written
+        dot_path = os.path.join(tmp_dir, "timeline.dot")
+        assert Path(dot_path).exists()
+        assert "digraph" in source


### PR DESCRIPTION
Implements main CLI with run/visualize/scenario/list-scenarios subcommands, graph visualization with DOT/PNG/SVG export, status-based node coloring, and execution timeline rendering.

## What's new

### `src/cli.py` — Main CLI entry point
- `papog run --goal "..." [--workers N] [--max-retries N] [--output-dir DIR]` — Run a goal through the full PAPoG pipeline
- `papog visualize --goal "..." [--output FILE] [--format dot|png|svg]` — Decompose a goal and visualize the task graph
- `papog scenario --name NAME [--workers N]` — Run a predefined benchmark scenario
- `papog list-scenarios` — List available scenarios
- Pretty-prints execution results (reuses format_result from benchmark.py)
- Returns proper exit codes (0 = success, 1 = failures)

### `src/visualizer.py` — Graph visualization module
- `export_dot(graph, filepath)` — Always works, no external deps
- `export_png(graph, filepath)` — Requires graphviz Python package + dot binary
- `export_svg(graph, filepath)` — Requires graphviz Python package + dot binary
- Color-coded nodes by status: PENDING=gray, RUNNING=blue, COMPLETED=green, FAILED=red, SKIPPED=orange
- Node labels show id + truncated description
- Dependency edges with arrows
- `render_execution_timeline(result, filepath)` — Timeline visualization from BenchmarkResult
- Graceful degradation when graphviz binary is missing

### Tests
- 37 new tests across `tests/test_cli.py` and `tests/test_visualizer.py`
- All 440 tests pass (2 skipped: PNG/SVG tests skip when dot binary unavailable)